### PR TITLE
Re-use become logic to disable output paging

### DIFF
--- a/plugins/terminal/icx.py
+++ b/plugins/terminal/icx.py
@@ -48,18 +48,13 @@ class TerminalModule(TerminalBase):
         re.compile(br"Errno")
     ]
 
+
     def on_open_shell(self):
+        self.on_become(passwd=self._connection._play_context.password)
         try:
-            commands = ('{"command": "' + "en" + '", "prompt": "Password:", "answer": "' +
-                        self._connection._play_context.password + '"}',
-                        '{"command": "skip"}')
-            for cmd in commands:
-                self._exec_cli_command(cmd)
+            self._exec_cli_command(b'skip')
         except AnsibleConnectionFailure:
-            try:
-                self._exec_cli_command(b'skip')
-            except AnsibleConnectionFailure:
-                raise AnsibleConnectionFailure('unable to set terminal parameters')
+            raise AnsibleConnectionFailure('unable to set terminal parameters')
 
     def __del__(self):
         try:


### PR DESCRIPTION
Pretty self-explanatory. A slightly nicer implementation might factor out the 'become' logic to a separate method and then call that method from both `on_open_shell` and `on_become`, but this patch has a smaller diff.