### PR TITLE
patch icx.py

### DIFF
--- a/plugins/terminal/icx.py
+++ b/plugins/terminal/icx.py
@@ -63,7 +63,7 @@ class TerminalModule(TerminalBase):
 
     def __del__(self):
         try:
-            self.close()
+            self._connection.close()
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/prube194/git/netswitch/netswitch-hardening/.collections/ansible_collections/commscope/icx/plugins/terminal/icx.py", line 66, in __del__
    self.close()
    ^^^^^^^^^^
AttributeError: 'TerminalModule' object has no attribute 'close'