### PR TITLE
Ajust regex to handle one or more spaces for LLDP system name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ commscope.icx.icx_l3_interface|Manage Layer-3 interfaces on Ruckus ICX 7K series
 commscope.icx.icx_linkagg|Manage link aggregation groups on Ruckus ICX 7K series switches
 commscope.icx.icx_lldp|Manage LLDP configuration on Ruckus ICX 7K series switches
 commscope.icx.icx_logging|Manage logging on Ruckus ICX 7K series switches
+commscope.icx.icx_ntp|Manage NTP server configuration on Ruckus ICX 7K series switches
 commscope.icx.icx_ping|Tests reachability using ping from Ruckus ICX 7K series switches
 commscope.icx.icx_qos|Configures qos features on ICX 7K series switches
 commscope.icx.icx_rate_limit|Configures rate limit on ICX 7K switch

--- a/plugins/modules/icx_facts.py
+++ b/plugins/modules/icx_facts.py
@@ -498,7 +498,7 @@ class Interfaces(FactsBase):
             return match.group(1)
 
     def parse_lldp_system_name(self, data):
-        match = re.search(r'System name *: *"(.+)"$', data, re.M | re.I)
+        match = re.search(r'System name\s*:\s*\"?(.*?)\"?$', data, re.M | re.I)
         if match:
             return match.group(1)
 

--- a/plugins/modules/icx_facts.py
+++ b/plugins/modules/icx_facts.py
@@ -462,13 +462,17 @@ class Interfaces(FactsBase):
     def parse_neighbors(self, neighbors):
         facts = dict()
         for entry in neighbors.split('Local '):
-            if entry == '':
+            entry = entry.strip()
+            if not entry:
                 continue
             intf = self.parse_lldp_intf(entry)
+            if not intf:
+                continue
             if intf not in facts:
                 facts[intf] = list()
             fact = dict()
             fact['Port ID'] = self.parse_lldp_portid(entry)
+            fact['Port Description'] = self.parse_lldp_port_desc(entry)
             fact['System name'] = self.parse_lldp_system_name(entry)
             fact['System description'] = self.parse_lldp_system_desc(entry)
             fact['Neighbor'] = self.parse_lldp_neighbor(entry)
@@ -543,9 +547,9 @@ class Interfaces(FactsBase):
             return match.group(1)
 
     def parse_lldp_intf(self, data):
-        match = re.search(r'^port: (.+)$', data, re.M)
+        match = re.search(r'^port:\s*(.+)$', data, re.M | re.I)
         if match:
-            return match.group(1)
+            return match.group(1).strip()
 
     def parse_lldp_system_name(self, data):
         match = re.search(r'System name\s*:\s*\"?(.*?)\"?$', data, re.M | re.I)
@@ -554,6 +558,11 @@ class Interfaces(FactsBase):
 
     def parse_lldp_portid(self, data):
         match = re.search(r'Port ID.*: *(.+)$', data, re.M | re.I)
+        if match:
+            return match.group(1)
+
+    def parse_lldp_port_desc(self, data):
+        match = re.search(r'Port description\s*:\s*\"?(.*?)\"?$', data, re.M | re.I)
         if match:
             return match.group(1)
 

--- a/plugins/modules/icx_facts.py
+++ b/plugins/modules/icx_facts.py
@@ -473,6 +473,7 @@ class Interfaces(FactsBase):
             fact = dict()
             fact['Port ID'] = self.parse_lldp_portid(entry)
             fact['Port Description'] = self.parse_lldp_port_desc(entry)
+            fact['System capabilities'] = self.parse_lldp_system_capabilities(entry)
             fact['System name'] = self.parse_lldp_system_name(entry)
             fact['System description'] = self.parse_lldp_system_desc(entry)
             fact['Neighbor'] = self.parse_lldp_neighbor(entry)
@@ -563,6 +564,11 @@ class Interfaces(FactsBase):
 
     def parse_lldp_port_desc(self, data):
         match = re.search(r'Port description\s*:\s*\"?(.*?)\"?$', data, re.M | re.I)
+        if match:
+            return match.group(1)
+
+    def parse_lldp_system_capabilities(self, data):
+        match = re.search(r'System capabilities\s*:\s*\"?(.*?)\"?$', data, re.M | re.I)
         if match:
             return match.group(1)
 

--- a/plugins/modules/icx_facts.py
+++ b/plugins/modules/icx_facts.py
@@ -140,10 +140,10 @@ class FactsBase(object):
         self.responses = None
 
     def populate(self):
-        self.responses = run_commands(self.module, commands=self.COMMANDS, check_rc=False)
+        self.responses = run_commands(self.module, commands=self.COMMANDS)
 
     def run(self, cmd):
-        return run_commands(self.module, commands=cmd, check_rc=False)
+        return run_commands(self.module, commands=cmd)
 
 
 class Default(FactsBase):
@@ -154,7 +154,7 @@ class Default(FactsBase):
         super(Default, self).run(['skip'])
         super(Default, self).populate()
         data = self.responses[2]
-        det = {}
+        det = dict()
         if data:
             det = self.parse_unit(data)
 
@@ -164,23 +164,40 @@ class Default(FactsBase):
             self.facts['model'] = self.parse_model(data)
             self.facts['image'] = self.parse_image(data)
             self.facts['hostname'] = self.parse_hostname(self.responses[0])
-            self.facts['info'] = 'Unit' + det['Unit'] + ':' + det['model'] + ', ' + self.parse_serialnum(data, det['Unit'])
+            unit = det.get('Unit') or self.parse_primary_unit(data)
+            model = det.get('model') or self.facts.get('model')
+            serial = self.parse_serialnum(data, unit)
+            if serial:
+                self.facts['serialnum'] = serial
+
+            if unit:
+                info = 'Unit' + unit
+                if model:
+                    info += ':' + model
+                if serial:
+                    info += ', ' + serial
+            else:
+                info = ', '.join([v for v in [model, serial] if v])
+
+            if info:
+                self.facts['info'] = info
             self.parse_stacks(data)
 
-    def parse_serialnum(self, data, unit):
-        try:
-            match1 = re.search("UNIT " + unit + ": SL .*?. Software", data, re.DOTALL)
-            if match1:
-                line = match1.group(0)
-                match2 = re.search(r'Serial  #:(\S+)', line)
-                if match2:
-                    serial_num = match2.group(1)
-                    return serial_num
-        except:
-            return ""
+    def parse_serialnum(self, data, unit=None):
+        if unit:
+            match = re.search(r'UNIT\s+%s: SL .*?Serial\s+#:\s*(\S+)' % re.escape(unit), data, re.DOTALL | re.M)
+            if match:
+                return match.group(1)
+
+        for pattern in [r'^System [Ss]erial [Nn]umber\s*:\s*(\S+)', r'Serial\s+#:\s*(\S+)']:
+            match = re.search(pattern, data, re.M)
+            if match:
+                return match.group(1)
+
+        return ""
 
     def parse_version(self, data):
-        match = re.search(r'SW: Version ([0-9]+.[0-9]+.[0-9a-zA-Z]+)', data)
+        match = re.search(r'SW:\s+Version\s+([^\s,]+)', data)
         if match:
             return match.group(1)
 
@@ -190,7 +207,7 @@ class Default(FactsBase):
             return match.group(1)
 
     def parse_model(self, data):
-        match = re.search(r'HW: (\S+ \S+)', data, re.M)
+        match = re.search(r'^\s*HW:\s+(.+)$', data, re.M)
         if match:
             return match.group(1)
 
@@ -200,19 +217,31 @@ class Default(FactsBase):
             return match.group(1)
 
     def parse_unit(self, data):
-        match = re.search(r'.*  (active|alone)  .*', data)
+        match = re.search(r'^\s*(\d+)\s{2,}(\S+)\s{2,}(active|alone)\b', data, re.M | re.I)
         if match:
-            det = match.group(0)
-            unit = det.split('  ')[0]
-            model = det.split('  ')[1]
-            return {'Unit': unit, 'model': model.split(' ')[1]}
+            return {'Unit': match.group(1), 'model': match.group(2)}
+
+        match = re.search(r'UNIT\s+(\d+):\s+SL\s+\d+:\s+(\S+)', data, re.M | re.I)
+        if match:
+            return {'Unit': match.group(1), 'model': match.group(2)}
+
+        return dict()
+
+    def parse_primary_unit(self, data):
+        match = re.search(r'UNIT\s+(\d+):\s+SL\s+\d+:', data, re.M | re.I)
+        if match:
+            return match.group(1)
+
+        return ""
 
     def parse_stacks(self, data):
-        match = re.findall(r'UNIT [1-9]+: SL [1-9]+: (\S+)', data, re.M)
+        match = re.findall(r'UNIT [1-9]+: SL [1-9]+: (\S+)', data, re.M | re.I)
         if match:
             self.facts['stacked_models'] = match
 
-        match = re.findall(r'^System [Ss]erial [Nn]umber\s+: (\S+)', data, re.M)
+        match = re.findall(r'Serial\s+#:\s*(\S+)', data, re.M)
+        if not match:
+            match = re.findall(r'^System [Ss]erial [Nn]umber\s*:\s*(\S+)', data, re.M)
         if match:
             self.facts['stacked_serialnums'] = match
 
@@ -364,32 +393,53 @@ class Interfaces(FactsBase):
 
     def populate_ipv6_interfaces(self, data):
         parts = data.split("\n")
+        key = None
+        interface_type = None
         for line in parts:
-            match = re.match(r'\W*interface \S+ (\S+)', line)
+            match = re.match(r'\W*interface (\S+) (\S+)', line)
             if match:
-                key = match.group(0)
-                try:
-                    self.facts['interfaces'][key]['ipv6'] = list()
-                    self.facts['interfaces'][key]['ipv4'] = list()
-                except KeyError:
+                intf_type = match.group(1).lower()
+                intf_id = match.group(2)
+                key, interface_type = self.normalize_interface_key(intf_type, intf_id)
+                if key not in self.facts['interfaces']:
                     self.facts['interfaces'][key] = dict()
+                if 'ipv6' not in self.facts['interfaces'][key]:
                     self.facts['interfaces'][key]['ipv6'] = list()
-                    self.facts['interfaces'][key]['ipv4'] = list()
-                self.facts['interfaces'][key]['ipv6'] = list()
-                self.facts['interfaces'][key]['ipv4'] = list()
-                interface_type = key.split(' ')
-                interface_type = ' '.join((interface_type[1], interface_type[2]))
                 continue
+
+            if key is None:
+                continue
+
             match = re.match(r'\W+ipv6 address (\S+)/(\S+)', line)
             match_ipv4 = re.match(r'\W+ip address (\S+) (\S+)', line)
 
             if match_ipv4:
                 self.add_ip_address(match_ipv4.group(1), "ipv4", str(interface_type))
-                self.facts['interfaces'][key]['ipv4'].append({"address": match_ipv4.group(1), "subnet": match_ipv4.group(2)})
+                ipv4 = {"address": match_ipv4.group(1), "subnet": match_ipv4.group(2)}
+                if 'ipv4' not in self.facts['interfaces'][key]:
+                    self.facts['interfaces'][key]['ipv4'] = ipv4
+                elif isinstance(self.facts['interfaces'][key]['ipv4'], list):
+                    if ipv4 not in self.facts['interfaces'][key]['ipv4']:
+                        self.facts['interfaces'][key]['ipv4'].append(ipv4)
+                elif self.facts['interfaces'][key]['ipv4'] != ipv4:
+                    self.facts['interfaces'][key]['ipv4'] = [self.facts['interfaces'][key]['ipv4'], ipv4]
 
             if match:
                 self.add_ip_address(match.group(1), "ipv6", str(interface_type))
-                self.facts['interfaces'][key]['ipv6'].append({"address": match.group(1), "subnet": match.group(2)})
+                ipv6 = {"address": match.group(1), "subnet": match.group(2)}
+                if ipv6 not in self.facts['interfaces'][key]['ipv6']:
+                    self.facts['interfaces'][key]['ipv6'].append(ipv6)
+
+    def normalize_interface_key(self, interface_type, interface_id):
+        if interface_type == 'ethernet':
+            return interface_id, interface_id
+        if interface_type == 'management':
+            return 'mgmt' + interface_id, 'management ' + interface_id
+        if interface_type == 've':
+            return 've' + interface_id, 've ' + interface_id
+        if interface_type == 'lag':
+            return interface_id, 'lag ' + interface_id
+        return interface_type + interface_id, interface_type + ' ' + interface_id
 
     def add_ip_address(self, address, family, interface_type):
         if family == 'ipv4':

--- a/plugins/modules/icx_ntp.py
+++ b/plugins/modules/icx_ntp.py
@@ -1,0 +1,173 @@
+#!/usr/bin/python
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: icx_ntp
+author: "Ruckus Wireless (@Commscope)"
+short_description: Manage NTP server configuration on Ruckus ICX 7000 series switches
+description:
+  - This module provides declarative management of NTP servers on
+    Ruckus ICX 7000 series switches.
+  - The module manages the server addresses configured under the
+    C(ntp) submode.
+notes:
+  - Tested against ICX 10.1.
+  - For information on using ICX platform, see L(the ICX OS Platform Options guide,../network/user_guide/platform_icx.html).
+options:
+  servers:
+    description:
+      - Ordered list of NTP server addresses or hostnames.
+      - When I(state=present), the configured NTP server list will be reconciled to match this list.
+      - When I(state=absent), the listed servers will be removed.
+    type: list
+    elements: str
+    required: true
+  state:
+    description:
+      - State of the NTP server configuration.
+    type: str
+    default: present
+    choices: ['present', 'absent']
+  check_running_config:
+    description:
+      - Check running configuration. This can be set as environment variable.
+       Module will use environment variable value(default:False), unless it is overridden, by specifying it as module parameter.
+    type: bool
+    default: no
+'''
+
+EXAMPLES = """
+- name: Configure NTP servers
+  community.network.icx_ntp:
+    servers:
+      - 10.126.11.12
+      - 10.138.11.12
+
+- name: Remove one NTP server
+  community.network.icx_ntp:
+    servers:
+      - 10.126.11.12
+    state: absent
+"""
+
+RETURN = """
+commands:
+  description: The list of configuration mode commands to send to the device
+  returned: always
+  type: list
+  sample:
+    - ntp
+    - server 10.126.11.12
+"""
+
+
+import re
+
+from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible_collections.commscope.icx.plugins.module_utils.network.icx.icx import get_config, load_config
+
+
+def diff_list(want, have):
+    adds = [w for w in want if w not in have]
+    removes = [h for h in have if h not in want]
+    return adds, removes
+
+
+def parse_ntp_servers(config):
+    servers = []
+    in_ntp = False
+
+    for line in config.splitlines():
+        stripped = line.strip()
+        if stripped == 'ntp':
+            in_ntp = True
+            continue
+
+        if not in_ntp:
+            continue
+
+        if stripped == '!':
+            break
+
+        if line and not line[0].isspace():
+            break
+
+        match = re.match(r'^\s+server\s+(\S+)', line)
+        if match:
+            servers.append(match.group(1))
+
+    return servers
+
+
+def map_config_to_obj(module):
+    compare = module.params['check_running_config']
+    config = get_config(module, None, compare=compare)
+    return {'servers': parse_ntp_servers(config)}
+
+
+def map_params_to_obj(module):
+    return {
+        'servers': module.params['servers'] or [],
+        'state': module.params['state'],
+    }
+
+
+def map_obj_to_commands(want, have, module):
+    state = module.params['state']
+    commands = []
+
+    if state == 'present':
+        adds, removes = diff_list(want['servers'], have['servers'])
+        if adds or removes:
+            commands.append('ntp')
+            for server in removes:
+                commands.append('no server %s' % server)
+            for server in adds:
+                commands.append('server %s' % server)
+
+    elif state == 'absent':
+        if module.params['check_running_config']:
+            removes = [server for server in want['servers'] if server in have['servers']]
+        else:
+            removes = want['servers']
+
+        if removes:
+            commands.append('ntp')
+            for server in removes:
+                commands.append('no server %s' % server)
+
+    return commands
+
+
+def main():
+    argument_spec = dict(
+        servers=dict(type='list', elements='str', required=True),
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        check_running_config=dict(default=False, type='bool', fallback=(env_fallback, ['ANSIBLE_CHECK_ICX_RUNNING_CONFIG']))
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    result = {'changed': False}
+
+    want = map_params_to_obj(module)
+    have = map_config_to_obj(module)
+    commands = map_obj_to_commands(want, have, module)
+    result['commands'] = commands
+
+    if commands:
+        if not module.check_mode:
+            load_config(module, commands)
+        result['changed'] = True
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/icx_system.py
+++ b/plugins/modules/icx_system.py
@@ -334,52 +334,56 @@ def parse_aaa_servers(config):
     obj = []
     for line in configlines:
         auth_key_type = []
-        if 'radius-server' in line or 'tacacs-server' in line:
-            aaa_type = 'radius' if 'radius-server' in line else 'tacacs'
-            match = re.search(r'(host ipv6 (\S+))|(host (\S+))', line)
-            if match:
-                hostname = match.group(2) if match.group(2) is not None else match.group(4)
-            match = re.search(r'auth-port ([0-9]+)', line)
-            if match:
-                auth_port_num = match.group(1)
-            else:
-                auth_port_num = None
-            match = re.search(r'acct-port ([0-9]+)', line)
-            if match:
-                acct_port_num = match.group(1)
-            else:
-                acct_port_num = None
-            match = re.search(r'acct-port [0-9]+ (\S+)', line)
+        if not (line.startswith('radius-server host ') or line.startswith('tacacs-server host ')):
+            continue
+
+        aaa_type = 'radius' if line.startswith('radius-server host ') else 'tacacs'
+        match = re.search(r'host(?: ipv6)? (\S+)', line)
+        if not match:
+            continue
+        hostname = match.group(1)
+
+        match = re.search(r'auth-port ([0-9]+)', line)
+        if match:
+            auth_port_num = match.group(1)
+        else:
+            auth_port_num = None
+        match = re.search(r'acct-port ([0-9]+)', line)
+        if match:
+            acct_port_num = match.group(1)
+        else:
+            acct_port_num = None
+        match = re.search(r'acct-port [0-9]+ (\S+)', line)
+        if match:
+            acct_type = match.group(1)
+        else:
+            acct_type = None
+        if aaa_type == 'tacacs':
+            match = re.search(r'auth-port [0-9]+ (\S+)', line)
             if match:
                 acct_type = match.group(1)
             else:
                 acct_type = None
-            if aaa_type == 'tacacs':
-                match = re.search(r'auth-port [0-9]+ (\S+)', line)
-                if match:
-                    acct_type = match.group(1)
-                else:
-                    acct_type = None
-            match = re.search(r'(dot1x)', line)
-            if match:
-                auth_key_type.append('dot1x')
-            match = re.search(r'(mac-auth)', line)
-            if match:
-                auth_key_type.append('mac-auth')
-            match = re.search(r'(web-auth)', line)
-            if match:
-                auth_key_type.append('web-auth')
+        match = re.search(r'(dot1x)', line)
+        if match:
+            auth_key_type.append('dot1x')
+        match = re.search(r'(mac-auth)', line)
+        if match:
+            auth_key_type.append('mac-auth')
+        match = re.search(r'(web-auth)', line)
+        if match:
+            auth_key_type.append('web-auth')
 
-            obj.append({
-                'type': aaa_type,
-                'hostname': hostname,
-                'auth_port_type': 'auth-port',
-                'auth_port_num': auth_port_num,
-                'acct_port_num': acct_port_num,
-                'acct_type': acct_type,
-                'auth_key': None,
-                'auth_key_type': set(auth_key_type) if len(auth_key_type) > 0 else None
-            })
+        obj.append({
+            'type': aaa_type,
+            'hostname': hostname,
+            'auth_port_type': 'auth-port',
+            'auth_port_num': auth_port_num,
+            'acct_port_num': acct_port_num,
+            'acct_type': acct_type,
+            'auth_key': None,
+            'auth_key_type': set(auth_key_type) if len(auth_key_type) > 0 else None
+        })
 
     return obj
 

--- a/plugins/terminal/icx.py
+++ b/plugins/terminal/icx.py
@@ -15,8 +15,7 @@ import json
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br".*[\r\n]?[\w\+\-\.:\/\[\]]+(?:\([^\)]+\)){0,3}(?:[>#]) ?.*"),
-        # re.compile(br"[\r\n]?[\w\+\-\.:\/\[\]]+(?:\([^\)]+\)){0,3}(?:[>#]) ?$"),
+        re.compile(br"(?:^|[\r\n])[\w@\+\-\.:\/\[\]]+(?:\([^\)]+\)){0,3}(?:[>#]) ?$"),
         re.compile(br"Finished downloading public key file!")
     ]
 

--- a/tests/unit/plugins/modules/network/icx/fixtures/icx_ntp_config.cfg
+++ b/tests/unit/plugins/modules/network/icx/fixtures/icx_ntp_config.cfg
@@ -1,0 +1,9 @@
+hostname icx-lab
+!
+ntp
+ server 172.16.1.10
+ server 172.16.1.11 burst version 4
+!
+!
+interface ethernet 1/1/1
+!

--- a/tests/unit/plugins/modules/network/icx/test_icx_ntp.py
+++ b/tests/unit/plugins/modules/network/icx/test_icx_ntp.py
@@ -1,0 +1,76 @@
+# Copyright: (c) 2019, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.commscope.icx.tests.unit.compat.mock import patch
+from ansible_collections.commscope.icx.plugins.modules import icx_ntp
+from ansible_collections.commscope.icx.tests.unit.plugins.modules.utils import set_module_args
+from .icx_module import TestICXModule, load_fixture
+
+
+class TestICXNtpModule(TestICXModule):
+
+    module = icx_ntp
+
+    def setUp(self):
+        super(TestICXNtpModule, self).setUp()
+
+        self.mock_get_config = patch('ansible_collections.commscope.icx.plugins.modules.icx_ntp.get_config')
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch('ansible_collections.commscope.icx.plugins.modules.icx_ntp.load_config')
+        self.load_config = self.mock_load_config.start()
+
+        self.set_running_config()
+
+    def tearDown(self):
+        super(TestICXNtpModule, self).tearDown()
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+
+    def load_fixtures(self, commands=None):
+        def load_file(*args, **kwargs):
+            module = args[0]
+            if module.params['check_running_config'] is True:
+                return load_fixture('icx_ntp_config.cfg').strip()
+            return ''
+
+        self.get_config.side_effect = load_file
+        self.load_config.return_value = None
+
+    def test_parse_ntp_servers(self):
+        config = load_fixture('icx_ntp_config.cfg')
+        self.assertEqual(
+            icx_ntp.parse_ntp_servers(config),
+            ['172.16.1.10', '172.16.1.11']
+        )
+
+    def test_icx_ntp_add_servers_without_compare(self):
+        set_module_args(dict(servers=['172.16.1.10', '172.16.1.11']))
+        result = self.execute_module(changed=True, sort=False)
+        self.assertEqual(result['commands'], ['ntp', 'server 172.16.1.10', 'server 172.16.1.11'])
+
+    def test_icx_ntp_reconcile_servers(self):
+        set_module_args(dict(
+            servers=['172.16.1.10', '10.200.1.1'],
+            check_running_config=True
+        ))
+        result = self.execute_module(changed=True, sort=False)
+        self.assertEqual(result['commands'], ['ntp', 'no server 172.16.1.11', 'server 10.200.1.1'])
+
+    def test_icx_ntp_remove_servers(self):
+        set_module_args(dict(
+            servers=['172.16.1.11'],
+            state='absent',
+            check_running_config=True
+        ))
+        result = self.execute_module(changed=True, sort=False)
+        self.assertEqual(result['commands'], ['ntp', 'no server 172.16.1.11'])
+
+    def test_icx_ntp_no_change(self):
+        set_module_args(dict(
+            servers=['172.16.1.10', '172.16.1.11'],
+            check_running_config=True
+        ))
+        self.execute_module(changed=False)

--- a/tests/unit/plugins/modules/network/icx/test_icx_system.py
+++ b/tests/unit/plugins/modules/network/icx/test_icx_system.py
@@ -153,7 +153,6 @@ class TestICXSystemModule(TestICXModule):
                 'tacacs-server host ansible.com'
             ]
             self.execute_module(changed=True, commands=commands)
-
         else:
             commands = [
                 'hostname ruckus',
@@ -162,3 +161,50 @@ class TestICXSystemModule(TestICXModule):
                 'tacacs-server host ansible.com'
             ]
             self.execute_module(changed=True, commands=commands)
+
+    def test_parse_aaa_servers_ignores_global_radius_settings(self):
+        config = """
+radius-server dead-time 1
+radius-server accounting interim-updates
+radius-server accounting interim-interval 5
+radius-server host 172.16.1.10 auth-port 1812 acct-port 1813 default key XXX dot1x mac-auth web-auth
+"""
+        self.assertEqual(
+            icx_system.parse_aaa_servers(config),
+            [dict(
+                type='radius',
+                hostname='172.16.1.10',
+                auth_port_type='auth-port',
+                auth_port_num='1812',
+                acct_port_num='1813',
+                acct_type='default',
+                auth_key=None,
+                auth_key_type={'dot1x', 'mac-auth', 'web-auth'}
+            )]
+        )
+
+    def test_icx_system_absent_with_global_radius_settings(self):
+        set_module_args(dict(
+            aaa_servers=[dict(
+                type='radius',
+                hostname='172.16.1.10',
+                auth_port_type='auth-port',
+                auth_port_num='1812',
+                acct_port_num='1813',
+                acct_type='default',
+                auth_key='doesntmatter',
+                auth_key_type=['dot1x', 'mac-auth', 'web-auth']
+            )],
+            state='absent',
+            check_running_config=True
+        ))
+        self.get_config.return_value = """
+radius-server dead-time 1
+radius-server accounting interim-updates
+radius-server accounting interim-interval 5
+radius-server host 172.16.1.10 auth-port 1812 acct-port 1813 default key XXX dot1x mac-auth web-auth
+"""
+        self.load_config.return_value = None
+
+        result = self.changed(changed=True)
+        self.assertEqual(result['commands'], ['no radius-server host 172.16.1.10'])

--- a/tests/unit/plugins/terminal/test_icx_terminal.py
+++ b/tests/unit/plugins/terminal/test_icx_terminal.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible_collections.commscope.icx.tests.unit.compat import unittest
+from ansible_collections.commscope.icx.plugins.terminal.icx import TerminalModule
+
+
+class TestICXTerminal(unittest.TestCase):
+
+    def test_terminal_prompt_regex_ignores_invalid_input_arrow(self):
+        response = (
+            b"totally-invalid-icx-command\r\n"
+            b"Invalid input ->totally-invalid-icx-command\r\n"
+            b"Type ? for a list\r\n"
+        )
+
+        self.assertIsNone(TerminalModule.terminal_stdout_re[0].search(response))
+
+    def test_terminal_prompt_regex_matches_real_prompt_after_error(self):
+        response = (
+            b"totally-invalid-icx-command\r\n"
+            b"Invalid input ->totally-invalid-icx-command\r\n"
+            b"Type ? for a list\r\n"
+            b"Node doesn't exist\r\n"
+            b"SSH@ICX7150-1(config)#"
+        )
+
+        match = TerminalModule.terminal_stdout_re[0].search(response)
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group().strip(), b"SSH@ICX7150-1(config)#")


### PR DESCRIPTION
Some switches omit the space before the system name in the LLDP string, this PR should fix LLDP system name resulting in null for access layer switches. Tested on ICX 7150, 7250, 7450 and 7650 switches on firmware 08.0.95n

