### PR TITLE
improve parse_serialnum icx_facts.py

### DIFF
--- a/plugins/modules/icx_facts.py
+++ b/plugins/modules/icx_facts.py
@@ -164,20 +164,15 @@ class Default(FactsBase):
             self.facts['model'] = self.parse_model(data)
             self.facts['image'] = self.parse_image(data)
             self.facts['hostname'] = self.parse_hostname(self.responses[0])
-            self.facts['info'] = 'Unit' + det['Unit'] + ':' + det['model'] + ', ' + self.parse_serialnum(data, det['Unit'])
+            self.facts['info'] = 'Unit' + det['Unit'] + ':' + det['model'] + ', ' + self.parse_serialnum(data)
             self.parse_stacks(data)
 
-    def parse_serialnum(self, data, unit):
+    def parse_serialnum(self, data):
         try:
-            match1 = re.search("UNIT " + unit + ": SL .*?. Software", data, re.DOTALL)
-            if match1:
-                line = match1.group(0)
-                match2 = re.search(r'Serial  #:(\S+)', line)
-                if match2:
-                    serial_num = match2.group(1)
-                    return serial_num
+            return re.search(r'Serial  #:(.+)', data).group(1).strip()
         except:
-            return ""
+            return "UNKNOWN"
+
 
     def parse_version(self, data):
         match = re.search(r'SW: Version ([0-9]+.[0-9]+.[0-9a-zA-Z]+)', data)


### PR DESCRIPTION
⚠️ I tested on a different version than the advertised one, but the changes shouldn't affect user who didn't encounter my issue ⚠️

Upon testing the fact gathering I stumbled upon a NoneType error.
<details>
<summary> Big error </summary>

```
The full traceback is:
Traceback (most recent call last):
  File "/Users/vic1707/Documents/Projects/homelab-config/.ansible/tmp/ansible-local-291901xhw5g0w/ansible-tmp-1746803311.857574-29191-211556707033450/AnsiballZ_icx_facts.py", line 107, in <module>
    _ansiballz_main()
    ~~~~~~~~~~~~~~~^^
  File "/Users/vic1707/Documents/Projects/homelab-config/.ansible/tmp/ansible-local-291901xhw5g0w/ansible-tmp-1746803311.857574-29191-211556707033450/AnsiballZ_icx_facts.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/vic1707/Documents/Projects/homelab-config/.ansible/tmp/ansible-local-291901xhw5g0w/ansible-tmp-1746803311.857574-29191-211556707033450/AnsiballZ_icx_facts.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.commscope.icx.plugins.modules.icx_facts', init_globals=dict(_module_fqn='ansible_collections.commscope.icx.plugins.modules.icx_facts', _modlib_path=modlib_path),
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                     run_name='__main__', alter_sys=True)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen runpy>", line 226, in run_module
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/var/folders/bx/0gr5271j0gd38_llvpr7_z7h0000gn/T/ansible_commscope.icx.icx_facts_payload_undfhix4/ansible_commscope.icx.icx_facts_payload.zip/ansible_collections/commscope/icx/plugins/modules/icx_facts.py", line 599, in <module>
  File "/var/folders/bx/0gr5271j0gd38_llvpr7_z7h0000gn/T/ansible_commscope.icx.icx_facts_payload_undfhix4/ansible_commscope.icx.icx_facts_payload.zip/ansible_collections/commscope/icx/plugins/modules/icx_facts.py", line 587, in main
  File "/var/folders/bx/0gr5271j0gd38_llvpr7_z7h0000gn/T/ansible_commscope.icx.icx_facts_payload_undfhix4/ansible_commscope.icx.icx_facts_payload.zip/ansible_collections/commscope/icx/plugins/modules/icx_facts.py", line 169, in populate
TypeError: can only concatenate str (not "NoneType") to str
fatal: [192.168.8.240]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/Users/vic1707/Documents/Projects/homelab-config/.ansible/tmp/ansible-local-291901xhw5g0w/ansible-tmp-1746803311.857574-29191-211556707033450/AnsiballZ_icx_facts.py\", line 107, in <module>\n    _ansiballz_main()\n    ~~~~~~~~~~~~~~~^^\n  File \"/Users/vic1707/Documents/Projects/homelab-config/.ansible/tmp/ansible-local-291901xhw5g0w/ansible-tmp-1746803311.857574-29191-211556707033450/AnsiballZ_icx_facts.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/vic1707/Documents/Projects/homelab-config/.ansible/tmp/ansible-local-291901xhw5g0w/ansible-tmp-1746803311.857574-29191-211556707033450/AnsiballZ_icx_facts.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.commscope.icx.plugins.modules.icx_facts', init_globals=dict(_module_fqn='ansible_collections.commscope.icx.plugins.modules.icx_facts', _modlib_path=modlib_path),\n    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n                     run_name='__main__', alter_sys=True)\n                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"<frozen runpy>\", line 226, in run_module\n  File \"<frozen runpy>\", line 98, in _run_module_code\n  File \"<frozen runpy>\", line 88, in _run_code\n  File \"/var/folders/bx/0gr5271j0gd38_llvpr7_z7h0000gn/T/ansible_commscope.icx.icx_facts_payload_undfhix4/ansible_commscope.icx.icx_facts_payload.zip/ansible_collections/commscope/icx/plugins/modules/icx_facts.py\", line 599, in <module>\n  File \"/var/folders/bx/0gr5271j0gd38_llvpr7_z7h0000gn/T/ansible_commscope.icx.icx_facts_payload_undfhix4/ansible_commscope.icx.icx_facts_payload.zip/ansible_collections/commscope/icx/plugins/modules/icx_facts.py\", line 587, in main\n  File \"/var/folders/bx/0gr5271j0gd38_llvpr7_z7h0000gn/T/ansible_commscope.icx.icx_facts_payload_undfhix4/ansible_commscope.icx.icx_facts_payload.zip/ansible_collections/commscope/icx/plugins/modules/icx_facts.py\", line 169, in populate\nTypeError: can only concatenate str (not \"NoneType\") to str\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE: No start of json char found\nSee stdout/stderr for the exact error",
    "rc": 1
}
```

</details>

TL/DR: error comes from 
```py
self.facts['info'] = 'Unit' + det['Unit'] + ':' + det['model'] + ', ' + self.parse_serialnum(data, det['Unit'])
```
as `self.parse_serialnum` returns `None`.

The current version of this function has 3 possible return values
 1. The SN if parsed correctly
 2. `""` (empty string) if a regex error occurs
 3. `None` if no regex errors and parsing didn't succeed

Here's the output from my switch ⚠️ possibly different than the output from advertised version ⚠️ 
```
Mycelium>show version
  Copyright (c) 1996-2016 Brocade Communications Systems, Inc. All rights reserved.
    UNIT 1: compiled on Apr 23 2020 at 10:57:06 labeled as ICX64R08030u
                (9871112 bytes) from Primary ICX64R08030u.bin
        SW: Version 08.0.30uT313
  Boot-Monitor Image size = 786944, Version:10.1.05T310 (kxz10105)
  HW: Stackable ICX6450-48-HPOE
==========================================================================
UNIT 1: SL 1: ICX6450-48P POE 48-port Management Module
         Serial  #: 2ax5o2jk68e
         License: ICX6450_PREM_ROUTER_SOFT_PACKAGE   (LID: H4CKTH3PLN8)
         P-ENGINE  0: type DEF0, rev 01
         P-ENGINE  1: type DEF0, rev 01
==========================================================================
UNIT 1: SL 2: ICX6450-SFP-Plus 4port 40G Module
==========================================================================
  800 MHz ARM processor ARMv5TE, 400 MHz bus
65536 KB flash memory
  512 MB DRAM
STACKID 1  system uptime is 2 hour(s) 18 minute(s) 36 second(s)
The system started at 00:00:42 GMT+00 Thu Jan 01 1970

 The system : started=warm start         reloaded=by "reload"
```

As you can see the serial line is `Serial  #: 2ax5o2jk68e` but the parsing regex is `r'Serial #:(\S+)'` which won't accept the space between the `:` and the SN.

This PR introduces 2 changes
1. upon error (regex or failed to parse) we return `"UNKNOWN"` for the serial number so retrieved infos looks like `"ansible_net_info": "Unit1:ICX6450-48P, UNKNOWN",` instead of `"ansible_net_info": "Unit1:ICX6450-48P, ",`
2. Changed the parsing regex to simplify the code, and support outputs giving `Serial  #: 2ax5o2jk68e` and `Serial  #:2ax5o2jk68e` so I don't affect existing users.